### PR TITLE
change version detection logic of BV files

### DIFF
--- a/wonambi/ioeeg/brainvision.py
+++ b/wonambi/ioeeg/brainvision.py
@@ -152,17 +152,25 @@ def _parse_ini(brainvision_file):
 
         line = f.readline().decode('ascii').strip()
         if (line in ['Brain Vision Data Exchange Header File Version 1.0',
-                     'Brain Vision Data Exchange Marker File, Version 1.0',
+                     'Brain Vision Data Exchange Marker File Version 1.0',
+                     'Brain Vision Data Exchange Header File, Version 1.0',
+                     'Brain Vision Data Exchange Marker File, Version 1.0'
                      'BrainVision Data Exchange Header File Version 1.0',
-                     'BrainVision Data Exchange Marker File, Version 1.0'):
+                     'BrainVision Data Exchange Marker File Version 1.0',
+                     'BrainVision Data Exchange Header File, Version 1.0',
+                     'BrainVision Data Exchange Marker File, Version 1.0']):
 
             ini['version'] = 1.0
             encoding = 'latin1'
 
         elif (line in ['Brain Vision Data Exchange Header File Version 2.0',
-                       'Brain Vision Data Exchange Marker File, Version 2.0',
+                       'Brain Vision Data Exchange Marker File Version 2.0',
+                       'Brain Vision Data Exchange Header File, Version 2.0',
+                       'Brain Vision Data Exchange Marker File, Version 2.0'
                        'BrainVision Data Exchange Header File Version 2.0',
-                       'BrainVision Data Exchange Marker File, Version 2.0',):
+                       'BrainVision Data Exchange Marker File Version 2.0',
+                       'BrainVision Data Exchange Header File, Version 2.0',
+                       'BrainVision Data Exchange Marker File, Version 2.0']):
             ini['version'] = 2.0
             encoding = 'utf-8'
 

--- a/wonambi/ioeeg/brainvision.py
+++ b/wonambi/ioeeg/brainvision.py
@@ -154,7 +154,7 @@ def _parse_ini(brainvision_file):
         if (line in ['Brain Vision Data Exchange Header File Version 1.0',
                      'Brain Vision Data Exchange Marker File Version 1.0',
                      'Brain Vision Data Exchange Header File, Version 1.0',
-                     'Brain Vision Data Exchange Marker File, Version 1.0'
+                     'Brain Vision Data Exchange Marker File, Version 1.0',
                      'BrainVision Data Exchange Header File Version 1.0',
                      'BrainVision Data Exchange Marker File Version 1.0',
                      'BrainVision Data Exchange Header File, Version 1.0',
@@ -166,7 +166,7 @@ def _parse_ini(brainvision_file):
         elif (line in ['Brain Vision Data Exchange Header File Version 2.0',
                        'Brain Vision Data Exchange Marker File Version 2.0',
                        'Brain Vision Data Exchange Header File, Version 2.0',
-                       'Brain Vision Data Exchange Marker File, Version 2.0'
+                       'Brain Vision Data Exchange Marker File, Version 2.0',
                        'BrainVision Data Exchange Header File Version 2.0',
                        'BrainVision Data Exchange Marker File Version 2.0',
                        'BrainVision Data Exchange Header File, Version 2.0',

--- a/wonambi/ioeeg/brainvision.py
+++ b/wonambi/ioeeg/brainvision.py
@@ -151,14 +151,18 @@ def _parse_ini(brainvision_file):
     with brainvision_file.open('rb') as f:
 
         line = f.readline().decode('ascii').strip()
-        if (line == 'Brain Vision Data Exchange Header File Version 1.0' or
-           line == 'Brain Vision Data Exchange Marker File, Version 1.0'):
+        if (line in ['Brain Vision Data Exchange Header File Version 1.0',
+                     'Brain Vision Data Exchange Marker File, Version 1.0',
+                     'BrainVision Data Exchange Header File Version 1.0',
+                     'BrainVision Data Exchange Marker File, Version 1.0'):
 
             ini['version'] = 1.0
             encoding = 'latin1'
 
-        elif (line == 'Brain Vision Data Exchange Header File Version 2.0' or
-              line == 'Brain Vision Data Exchange Marker File, Version 2.0'):
+        elif (line in ['Brain Vision Data Exchange Header File Version 2.0',
+                       'Brain Vision Data Exchange Marker File, Version 2.0',
+                       'BrainVision Data Exchange Header File Version 2.0',
+                       'BrainVision Data Exchange Marker File, Version 2.0',):
             ini['version'] = 2.0
             encoding = 'utf-8'
 


### PR DESCRIPTION
Some brainvision header files have BrainVision written together - this fixes their detection

Alternatively, a RegEx would be a more elegant solution.